### PR TITLE
feat(extract): add extractIdentifiers

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,0 +1,53 @@
+import type * as t from '@babel/types'
+
+/**
+ * Extract identifiers of the given node.
+ * @param node The node to extract.
+ * @param identifiers The array to store the extracted identifiers.
+ * @see https://github.com/vuejs/core/blob/1f6a1102aa09960f76a9af2872ef01e7da8538e3/packages/compiler-core/src/babelUtils.ts#L208
+ */
+export function extractIdentifiers(
+  node: t.Node,
+  identifiers: t.Identifier[] = [],
+): t.Identifier[] {
+  switch (node.type) {
+    case 'Identifier':
+      identifiers.push(node)
+      break
+
+    case 'MemberExpression':
+      // eslint-disable-next-line no-case-declarations
+      let object: any = node
+      while (object.type === 'MemberExpression') {
+        object = object.object
+      }
+      identifiers.push(object)
+      break
+
+    case 'ObjectPattern':
+      for (const prop of node.properties) {
+        if (prop.type === 'RestElement') {
+          extractIdentifiers(prop.argument, identifiers)
+        } else {
+          extractIdentifiers(prop.value, identifiers)
+        }
+      }
+      break
+
+    case 'ArrayPattern':
+      node.elements.forEach((element) => {
+        if (element) extractIdentifiers(element, identifiers)
+      })
+      break
+
+    case 'RestElement':
+      extractIdentifiers(node.argument, identifiers)
+      break
+
+    case 'AssignmentPattern':
+      extractIdentifiers(node.left, identifiers)
+      break
+  }
+
+  return identifiers
+}

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -15,14 +15,14 @@ export function extractIdentifiers(
       identifiers.push(node)
       break
 
-    case 'MemberExpression':
-      // eslint-disable-next-line no-case-declarations
+    case 'MemberExpression': {
       let object: any = node
       while (object.type === 'MemberExpression') {
         object = object.object
       }
       identifiers.push(object)
       break
+    }
 
     case 'ObjectPattern':
       for (const prop of node.properties) {
@@ -36,7 +36,7 @@ export function extractIdentifiers(
 
     case 'ArrayPattern':
       node.elements.forEach((element) => {
-        if (element) extractIdentifiers(element, identifiers)
+        element && extractIdentifiers(element, identifiers)
       })
       break
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './check'
 export * from './create'
+export * from './extract'
 export * from './lang'
 export * from './loc'
 export * from './parse'

--- a/tests/extract.test.ts
+++ b/tests/extract.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'vitest'
+import { babelParse, extractIdentifiers } from '../src'
+import type * as t from '@babel/types'
+
+describe('extract', () => {
+  test('extractIdentifiers', () => {
+    const ast = babelParse(`
+      const one = 1
+      const {
+        propA,
+        propB: aliasPropB,
+        propC = 33,
+        propD: aliasPropD = 44,
+        ...objRest
+      } = {
+        propA: 1,
+        propB: 2,
+        propC: 3,
+        propD: 4,
+        propE: 5,
+        propF: 6,
+      }
+      const [elOne, elTwo = 22, ...elRest] = [1, 2, 3, 4]    
+      memberExpressionObj.a
+    `)
+
+    const identifiers: t.Identifier[] = []
+
+    for (const b of ast.body) {
+      if (b.type === 'VariableDeclaration') {
+        for (const d of b.declarations) {
+          extractIdentifiers(d.id, identifiers)
+        }
+      }
+
+      if (b.type === 'ExpressionStatement') {
+        extractIdentifiers(b.expression, identifiers)
+      }
+    }
+
+    expect(
+      identifiers.map((id) => ({
+        name: id.name,
+      })),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "name": "one",
+        },
+        {
+          "name": "propA",
+        },
+        {
+          "name": "aliasPropB",
+        },
+        {
+          "name": "propC",
+        },
+        {
+          "name": "aliasPropD",
+        },
+        {
+          "name": "objRest",
+        },
+        {
+          "name": "elOne",
+        },
+        {
+          "name": "elTwo",
+        },
+        {
+          "name": "elRest",
+        },
+        {
+          "name": "memberExpressionObj",
+        },
+      ]
+    `)
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR is to add `extractIdentifiers`. The `extractIdentifiers` is now a fully copied version and I have added some test cases.

### Linked Issues

#37 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Indeed, the version from `vue/compiler-core` can't meet the demand of #37. For example, when resolving `ObjectProperty`, it just extracts the `value` without the `key`. In #37, after resolving, the `key` is to be `local` and the `value` is to be `exported`.

From my view, I may change the declaration of `extractIdentifiers` from 
```ts
function extractIdentifiers(node: t.Node, identifiers?: t.Identifier[]): t.Identifier[]
```
to
```ts
function extractIdentifiers<T = t.Identifier>(
    node: t.Node, 
    identifiers?: T[], 
    resolvers?: {
       onIdentifier?: (identifiers: T[], node: t.Identifier) => void; // have a default implementation
       onObjectProperty?: (identifiers: T[], node: t.ObjectProperty) => void; // have a default implementation
       // ... more if needed
}): T[]
```

It seems a little complex using the declaration above. Using another function is also a good choice, but it seems a little redundant. 🤣

Could you give me some advice? Or we can continue the context within #37?

