### PR TITLE
fix: JSXNamespacedName should not be inferred as references

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -351,7 +351,9 @@ export function isReferenced(
       return false
 
     // no: <div NODE="foo" />
+    // no: <div foo:NODE="foo" />
     case 'JSXAttribute':
+    case 'JSXNamespacedName':
       return false
 
     // no: [NODE] = [];

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import {
   babelParse,
   isCallOf,
@@ -245,6 +245,13 @@ describe('utils', () => {
           expect(isReferencedIdentifier(node, parent, parentStack)).toBe(true)
         }
       })
+    })
+
+    test('JSXNamespacedName should not be referenced', () => {
+      const ast = babelParse(`const Comp = <svg:circle foo:bar="" />`, 'tsx')
+      const onIdentifier = vi.fn()
+      walkIdentifiers(ast.body[0], onIdentifier)
+      expect(onIdentifier).toHaveBeenCalledTimes(0)
     })
   })
 

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -260,7 +260,7 @@ describe('utils', () => {
       )
     })
 
-    test('JSXNamespacedName should not be referenced', () => {
+    test('JSXNamespacedName should not be inferred as references', () => {
       const ast = babelParse(`const Comp = <svg:circle foo:bar="" />`, 'tsx')
       const onIdentifier = vi.fn()
       walkIdentifiers(ast.body[0], onIdentifier)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

```tsx
<div foo:bar="" />
//       ^^ should not be referenced.
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -^^